### PR TITLE
Add Wii Nunchuck Example and I2C read support

### DIFF
--- a/src/main/java/com/ociweb/device/testApps/NunchuckExampleApp.java
+++ b/src/main/java/com/ociweb/device/testApps/NunchuckExampleApp.java
@@ -1,0 +1,70 @@
+package com.ociweb.device.testApps;
+
+import com.ociweb.pronghorn.iot.i2c.impl.I2CNativeLinuxBacking;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A simple app that demonstrates interacting with a Wii Nunchuck via the Grove.
+ *
+ * All of the I2C commands used in this example was derived from the following
+ * webpages:
+ *
+ * http://rts.lab.asu.edu/web_325/CSE325_Assignment_6_F10.pdf
+ *
+ * http://www.robotshop.com/media/files/PDF/inex-zx-nunchuck-datasheet.pdf
+ *
+ * @author Brandon Sanders [brandon@alicorn.io]
+ */
+public class NunchuckExampleApp {
+    private static final Logger logger = LoggerFactory.getLogger(NunchuckExampleApp.class);
+
+    // Create a connection to the native Linux I2C lines.
+    private static final I2CNativeLinuxBacking i2c = new I2CNativeLinuxBacking();
+
+    // Address of the nunchuck.
+    public static final byte NUNCHUCK_ADDR = 0x52;
+
+    public static void main(String[] args) {
+        logger.info("Starting Wii Nunchuck example application.");
+
+        // Write 0x40 and 0x00 to initialize the nunchuck.
+        logger.info("Initializing Nunchuck.");
+        i2c.write(NUNCHUCK_ADDR, (byte) 0x40, (byte) 0x00);
+        logger.info("Nunchuck initialized.");
+
+        // Loop forever, reading from the nunchuck.
+        System.out.println("#### Wii Nunchuck Tracking Data ####");
+        System.out.println("");
+        byte[] response;
+        while (true) {
+            // Write 0x00 to the nunchuck to request data.
+            i2c.write(NUNCHUCK_ADDR, (byte) 0x00);
+
+            // Read the 6-byte response from the nunchuck.
+            response = i2c.read(NUNCHUCK_ADDR, 6);
+
+            // Decode response by XOR 0x17 and add 0x17.
+            for (int i = 0; i < response.length; i++) {
+                response[i] = (byte) ((response[i] ^ 0x17) + 0x17);
+            }
+
+            // Clear the most recent line so that we don't spew out tons of lines of content.
+            System.out.print("\r");
+            for (int i = 0; i < 100; i++) System.out.print(" ");
+            System.out.print("\r");
+
+            // Print out tracking data.
+            System.out.print(String.format("Stick (X %d Y %d) | Gyro (X %d Y %d Z %d) | Buttons (%d)",
+                                             response[0], response[1], response[2], response[3],
+                                             response[4], response[5]));
+
+            // Sleep for a bit.
+            try {
+                Thread.sleep(250);
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ociweb/pronghorn/iot/i2c/I2CBacking.java
+++ b/src/main/java/com/ociweb/pronghorn/iot/i2c/I2CBacking.java
@@ -13,15 +13,14 @@ public interface I2CBacking {
     /**
      * Reads a message from the I2C device at the specified address.
      *
-     * @param bufferSize Size of the byte buffer to read into (and return).
      * @param address Address of the I2C device to read, e.g., "0x32" for a
      *                GrovePi's LCD RGB backlight.
-     * @param message Array of bytes to write to the I2C device.
+     * @param bufferSize Size of the byte buffer to read into (and return).
      *
      * @return Data received from the I2C device, or an empty array if no
      *         data was received.
      */
-    byte[] read(int bufferSize, byte address, byte... message);
+    byte[] read(byte address, int bufferSize);
 
     /**
      * Writes a message to an I2C device at the specified address.

--- a/src/main/java/com/ociweb/pronghorn/iot/i2c/impl/I2CGroveJavaBacking.java
+++ b/src/main/java/com/ociweb/pronghorn/iot/i2c/impl/I2CGroveJavaBacking.java
@@ -112,7 +112,7 @@ public class I2CGroveJavaBacking implements I2CBacking {
         this.config = config;
     }
 
-    @Override public byte[] read(int bufferSize, byte address, byte... message) {
+    @Override public byte[] read(byte address, int bufferSize) {
         //TODO: Unimplemented.
         throw new RuntimeException("Bit-banged reads aren't supported yet.");
     }


### PR DESCRIPTION
This pull request adds I2C read support to the I2CNativeLinuxBacking and includes a simple demo application that uses the Wii Nunchuck. For some reason, the buttons on my Nunchuck were returning garbage data, but the gyro and joystick were working correctly.