### PR TITLE
Added draft javadocs for the Grove LCD RGB classes.

### DIFF
--- a/src/main/java/com/ociweb/iot/grove/Grove_LCD_RGB.java
+++ b/src/main/java/com/ociweb/iot/grove/Grove_LCD_RGB.java
@@ -1,494 +1,610 @@
 package com.ociweb.iot.grove;
 
-import java.io.IOException;
-import java.util.Arrays;
-
 import com.ociweb.iot.hardware.I2CConnection;
 import com.ociweb.iot.hardware.IODevice;
 import com.ociweb.iot.maker.CommandChannel;
 import com.ociweb.pronghorn.iot.i2c.I2CStage;
 import com.ociweb.pronghorn.iot.schema.I2CCommandSchema;
 import com.ociweb.pronghorn.pipe.DataOutputBlobWriter;
-import com.ociweb.pronghorn.util.Appendables;
 
 /**
- * TODO: This class probably needs to be renamed and moved; it's now both a simple API and collection of constants.
+ * Utility class for interacting with a Grove LCD RGB connected to a
+ * {@link CommandChannel}.
  *
  * @author Nathan Tippy
  * @author Brandon Sanders [brandon@alicorn.io]
  * @author Alex Herriott
  */
-public class Grove_LCD_RGB implements IODevice{ 
-
-
-	public static boolean isStarted = false;
-
-	// Current LCD_DISPLAYCONTROL states
-	private static int LCD_DISPLAY =Grove_LCD_RGB_Constants.LCD_DISPLAYON;
-	private static int LCD_CURSOR =Grove_LCD_RGB_Constants.LCD_CURSOROFF;
-	private static int LCD_BLINK =Grove_LCD_RGB_Constants.LCD_BLINKOFF;
-
-
-	public static boolean begin(CommandChannel target){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-		isStarted = true;
-
-		writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, Grove_LCD_RGB_Constants.LCD_TWO_LINES);
-		target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 5*Grove_LCD_RGB_Constants.MS_TO_NS);  // wait more than 4.1ms
-
-		// second try
-		writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, Grove_LCD_RGB_Constants.LCD_TWO_LINES);
-		target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 1*Grove_LCD_RGB_Constants.MS_TO_NS);
-
-		// third go
-		writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, Grove_LCD_RGB_Constants.LCD_TWO_LINES);
-		target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 1*Grove_LCD_RGB_Constants.MS_TO_NS);
-
-
-		// turn the display on with no cursor or blinking default
-		setDisplayControl(target);
-
-		// clear it off
-		displayClear(target);
-
-		// set the entry mode
-		//writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, LCD_SETDDRAMADDR, LCD_ENTRYMODESET | LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT);
-		target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 1*Grove_LCD_RGB_Constants.MS_TO_NS);
-
-		setCursor(target, 0, 0);
-		target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 1*Grove_LCD_RGB_Constants.MS_TO_NS);
-		target.i2cFlushBatch();
-		return true;
-	}
-
-	/**
-	 * <pre>
-	 * Creates a complete byte array that will set the text and color of a Grove RGB
-	 * LCD display when passed to a {@link com.ociweb.pronghorn.stage.test.ByteArrayProducerStage}
-	 * which is using chunk sizes of 3 and is being piped to a {@link I2CStage}.
-	 *
-	 * TODO: This function is currently causing the last letter of the text to be dropped
-	 *       when displayed on the Grove RGB LCD; there's currently a work-around that
-	 *       simply appends a space to the incoming text variable, but it's hackish
-	 *       and should be looked into more...
-	 *
-	 * @param text String to display on the Grove RGB LCD.
-	 * @param r 0-255 value for the Red color.
-	 * @param g 0-255 value for the Green color.
-	 * @param b 0-255 value for the Blue color.
-	 *
-	 * @return Formatted byte array which can be passed directly to a
-	 *         {@link com.ociweb.pronghorn.stage.test.ByteArrayProducerStage}.
-	 * </pre>
-	 */
-	public static boolean commandForTextAndColor(CommandChannel target, String text, int r, int g, int b) {
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-
-		showRGBColor(target, r, g, b);
-		showTwoLineText(target, text);
-		target.i2cFlushBatch();
-		return true;
-	}
-
-	public static boolean commandForColor(CommandChannel target, int r, int g, int b) {
-
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-
-		showRGBColor(target, r, g, b);
-
-		target.i2cFlushBatch();
-		return true;
-	}
-
-	public static boolean commandForText(CommandChannel target, CharSequence text) {
-
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-
-		showTwoLineText(target, text);        
-		target.i2cFlushBatch();
-
-		return true;
-	}
-
-	/**
-	 * Switches the lcd display on or off. Default is on
-	 * 
-	 * @param target CommandChannel to send command on
-	 * @param on boolean to set display to
-	 * @return boolean command is successful
-	 */
-	public static boolean commandForDisplay (CommandChannel target, boolean on){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-
-		if(on){
-			LCD_DISPLAY = Grove_LCD_RGB_Constants.LCD_DISPLAYON;
-		}else{
-			LCD_DISPLAY = Grove_LCD_RGB_Constants.LCD_DISPLAYOFF;
-		}
-		setDisplayControl(target);  
-		target.i2cFlushBatch();
-		return true;
-	}
-
-	/**
-	 * Switches the cursor on or off. Default is off
-	 * 
-	 * @param target CommandChannel to send command on
-	 * @param on boolean to set cursor to
-	 * @return boolean command is successful
-	 */
-	public static boolean commandForCursor (CommandChannel target, boolean on){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-
-		if(on){
-			LCD_CURSOR = Grove_LCD_RGB_Constants.LCD_CURSORON;
-		}else{
-			LCD_CURSOR = Grove_LCD_RGB_Constants.LCD_CURSOROFF;
-		}
-
-		setDisplayControl(target); 
-		target.i2cFlushBatch();
-
-		return true;
-	}
-
-	/**
-	 * Switches the blinking cursor on or off. Default is off
-	 * 
-	 * @param target CommandChannel to send command on
-	 * @param on boolean to set blink to
-	 * @return boolean command is successful
-	 */
-	public static boolean commandForBlink (CommandChannel target, boolean on){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-
-		if(on){
-			LCD_BLINK = Grove_LCD_RGB_Constants.LCD_BLINKON;
-		}else{
-			LCD_BLINK = Grove_LCD_RGB_Constants.LCD_BLINKOFF;
-		}
-
-		setDisplayControl(target);        
-		target.i2cFlushBatch();
-
-		return true;
-	}
-	
-	public static boolean clearDisplay(CommandChannel target){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-		displayClear(target);
-
-		target.i2cFlushBatch();
-		return true;
-	}
-
-	public static boolean setCursor(CommandChannel target, int col, int row){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-		col = (row == 0 ? col|0x80 : col|0xc0);
-		writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, col);
-		target.i2cFlushBatch();
-		return true;
-	}
-	
-	
-	
-	/////////////////////////////
-	////  Write text methods ////
-	/////////////////////////////
-
-	/**
-	 * Creates a custom char from an array of 8 bytes. Can save up to 8 custom chars in the LCD. 
-	 * @param target CommandChannel to send command on
-	 * @param location location 0-7 to store the charmap in the LCD
-	 * @param charMap Array of 8 bytes. Each byte is a row. Least significant 5 bits determines values within row
-	 */
-	public static boolean setCustomChar(CommandChannel target, int location,  byte charMap[]){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-		if(!isStarted){
-			begin(target);
-		}
-		assert(location < 8 && location >= 0) : "Only locations 0-7 are valid";
-		assert(charMap.length == 8) : "charMap must contain an array of 8 bytes";
-		location &= 0x7;
-		for (int i = 0; i < charMap.length; i++) {
-			charMap[i] &= 0x1F; //each element contains 5 bits
-		}
-
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)), Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR | (location<<3));
-		target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.CGRAM_SET_DELAY);
-		writeMultipleBytesToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, charMap, 0, charMap.length);
-		target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.DDRAM_WRITE_DELAY);
-		target.i2cFlushBatch();
-
-		//begin(target); //TODO: Seems to be necessary, but shouldn't be
-		return true;
-	}
-
-	/**
-	 * Writes an ascii char  with idx characterIdx. Locations 0-7 contain custom characters.
-	 * @param target CommandChannel to send command on
-	 * @param characterIdx Index of the character
-	 * @param row TODO
-	 * @param col TODO
-	 */
-	public static boolean writeChar(CommandChannel target, int characterIdx, int col, int row){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-		setCursor(target, col, row);
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)), Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, characterIdx);
-		target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.DDRAM_WRITE_DELAY);
-		target.i2cFlushBatch();
-
-		return true;
-	}
-
-	public static boolean writeMultipleChars(CommandChannel target, byte[] characterIdx, int col, int row){ //TODO: creates lots of garbage
-		return writeMultipleChars(target, characterIdx, 0, characterIdx.length, col, row);
-	}
-	
-	public static boolean writeMultipleChars(CommandChannel target, byte[] characterIdx, int startIdx, int length, int col, int row){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-		int iterator = startIdx;
-		int endOfLineIdx = 16-col;
-		int steps = 4;
-		setCursor(target, col, row);
-
-		while(iterator<length){
-			if(endOfLineIdx<Math.min(iterator+steps,length-1)){
-				writeMultipleBytesToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, 
-						characterIdx, iterator, endOfLineIdx-iterator);
-				iterator = endOfLineIdx;
-				endOfLineIdx+=16;
-				row = (row+1)&1;
-				setCursor(target, col, row);
-			}else{
-				writeMultipleBytesToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, 
-						characterIdx, iterator, Math.min(steps, length-iterator));
-				iterator += steps;		
-			}
-		}
-		target.i2cFlushBatch();
-		return true;
-	}
-	
-	public static boolean writeCharSequence(CommandChannel target, CharSequence text, int col, int row){
-		return writeCharSequence(target, text, 0, text.length(), col, row);
-	}
-	
-	public static boolean writeCharSequence(CommandChannel target, CharSequence text, int startIdx, int length, int col, int row){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-		int iterator = startIdx;
-		int endOfLineIdx = 16-col;
-		int steps = 4;
-		setCursor(target, col, row);
-		
-		while(iterator<length){
-			if(endOfLineIdx<Math.min(iterator+steps,length-1)){
-				writeCharSequenceToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, 
-						text, iterator, endOfLineIdx-iterator);
-				iterator = endOfLineIdx;
-				endOfLineIdx+=16;
-				row = (row+1)&1;
-				setCursor(target, col, row);
-			}else{
-				writeCharSequenceToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, 
-						text, iterator, Math.min(steps, length-iterator));
-				iterator += steps;		
-			}
-		}
-		
-		target.i2cFlushBatch();
-		return true;
-	}
-	
-	public static boolean writePaddedInt(CommandChannel target, int value, int length, int col, int row){
-		if (!target.i2cIsReady()) {
-			return false;
-		}
-		writeCharSequence(target, String.format("%0"+length+"d", value), col, row);
-		return true;
-	}
-
-
-
-	
-
-
-
-
-
-	//////////////////////////////
-	///    Private Methods    ////
-	//////////////////////////////
-
-	private static void setDisplayControl(CommandChannel target){
-		writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, 
-				Grove_LCD_RGB_Constants.LCD_DISPLAYCONTROL | LCD_DISPLAY | LCD_CURSOR | LCD_BLINK);
-		target.i2cDelay((Grove_LCD_RGB_Constants.LCD_ADDRESS), Grove_LCD_RGB_Constants.DISPLAY_SWITCH_DELAY);
-	}
-
-
-
-	private static void showRGBColor(CommandChannel target, int r, int g, int b) {
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 0, 0);
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 1, 0);
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 0x08, 0xaa);
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 4, r);
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 3, g);
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 2, b);
-	}
-
-	private static void displayClear(CommandChannel target) {
-		//clear display
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)), Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, Grove_LCD_RGB_Constants.LCD_CLEARDISPLAY);
-		target.i2cDelay((Grove_LCD_RGB_Constants.LCD_ADDRESS), Grove_LCD_RGB_Constants.SCREEN_CLEAR_DELAY);
-
-	}
-
-	private static void showTwoLineText(CommandChannel target, CharSequence text) {
-
-		if(!isStarted){
-			begin(target);
-		}
-		displayClear(target);
-
-		target.i2cDelay((Grove_LCD_RGB_Constants.LCD_ADDRESS), Grove_LCD_RGB_Constants.INPUT_SET_DELAY);
-		
-		int p = 0;
-		int start = 0;
-		while (p<text.length()) {
-			if (text.charAt(p++)=='\n') {					
-				writeSingleLine(target, text, start, p-1);// -1 to skip the \n
-				start = p;				
-			}			
-		}
-		assert(p==text.length());
-		writeSingleLine(target, text, start, p);
-
-	}
-
-	private static void writeSingleLine(CommandChannel target, CharSequence line, int p, int limit) {
-		int steps = 4;
-		
-		while (p<limit) {
-			writeUTF8ToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)), Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, line, p, Math.min(steps, limit-p) );
-			p+=steps;
-
-		}
-		//new line
-		writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)), Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, 0xc0);
-	}
-	
-	
-
-	private static void writeSingleByteToRegister(CommandChannel target, int address, int register, int value) {
-		
-			DataOutputBlobWriter<I2CCommandSchema> i2cPayloadWriter = target.i2cCommandOpen(address);
-
-			i2cPayloadWriter.writeByte(register);
-			i2cPayloadWriter.writeByte(value);          
-
-			target.i2cCommandClose();
-	
-	}
-
-	private static void writeMultipleBytesToRegister(CommandChannel target, int address, int register, byte[] values, int startIdx, int length) {
-	
-			DataOutputBlobWriter<I2CCommandSchema> i2cPayloadWriter = target.i2cCommandOpen(address);
-
-			i2cPayloadWriter.writeByte(register);
-			for (int i = startIdx; i < startIdx+length; i++) {
-				i2cPayloadWriter.writeByte(values[i]);
-			}
-
-			target.i2cCommandClose();
-
-	}
-
-	private static void writeCharSequenceToRegister(CommandChannel target, int address, int register, CharSequence values, int startIdx, int length){
-		
-			DataOutputBlobWriter<I2CCommandSchema> i2cPayloadWriter = target.i2cCommandOpen(address);
-
-			i2cPayloadWriter.writeByte(register);
-			i2cPayloadWriter.writeASCII(values.subSequence(startIdx, startIdx+length));
-
-			target.i2cCommandClose();
-
-	}
-	private static void writeUTF8ToRegister(CommandChannel target, int address, int register, CharSequence text, int pos, int len) {
-		
-			DataOutputBlobWriter<I2CCommandSchema> i2cPayloadWriter = target.i2cCommandOpen(address);
-
-			i2cPayloadWriter.writeByte(register);
-			DataOutputBlobWriter.encodeAsUTF8(i2cPayloadWriter, text, pos, len);
-
-			target.i2cCommandClose();
-
-	}
-
-	@Override
-	public boolean isInput() {
-		return false;
-	}
-	@Override
-	public boolean isOutput() {
-		return true;
-	}
-	@Override
-	public boolean isPWM() {
-		return false;
-	}
-	@Override
-	public int range() {
-		return 0;
-	}
-	@Override
-	public I2CConnection getI2CConnection() { //putting getI2CConnection in i2cOutput twigs allows setup commands to be sent
-		byte[] LCD_READCMD = {};
-		byte[] LCD_SETUP = {};
-		byte LCD_ADDR = 0x04;
-		byte LCD_BYTESTOREAD = 0;
-		byte LCD_REGISTER = 0;
-		return new I2CConnection(this, LCD_ADDR, LCD_READCMD, LCD_BYTESTOREAD, LCD_REGISTER, LCD_SETUP);
-	}
-
-	@Override
-	public int response() {       
-		return 20;      
-	}
-	@Override
-	public boolean isValid(byte[] backing, int position, int length, int mask) {
-		return true;
-	}
-
-	@Override
-	public int pinsUsed() {
-		return 1;
-	}
-
+public class Grove_LCD_RGB implements IODevice {
+
+    public static boolean isStarted = false;
+
+    // Current LCD_DISPLAYCONTROL states
+    private static int LCD_DISPLAY = Grove_LCD_RGB_Constants.LCD_DISPLAYON;
+    private static int LCD_CURSOR = Grove_LCD_RGB_Constants.LCD_CURSOROFF;
+    private static int LCD_BLINK = Grove_LCD_RGB_Constants.LCD_BLINKOFF;
+
+    /**
+     * Sets up a Grove LCD RGB display on a given {@link CommandChannel}.
+     *
+     * @param target {@link CommandChannel} of the I2C device for the Grove LCD RGB display.
+     *
+     * @return True if the device was successfully connected, and false otherwise.
+     */
+    public static boolean begin(CommandChannel target) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+        isStarted = true;
+
+        writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR,
+                                  Grove_LCD_RGB_Constants.LCD_TWO_LINES);
+        target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS,
+                        5 * Grove_LCD_RGB_Constants.MS_TO_NS);  // wait more than 4.1ms
+
+        // second try
+        writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR,
+                                  Grove_LCD_RGB_Constants.LCD_TWO_LINES);
+        target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 1 * Grove_LCD_RGB_Constants.MS_TO_NS);
+
+        // third go
+        writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR,
+                                  Grove_LCD_RGB_Constants.LCD_TWO_LINES);
+        target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 1 * Grove_LCD_RGB_Constants.MS_TO_NS);
+
+
+        // turn the display on with no cursor or blinking default
+        setDisplayControl(target);
+
+        // clear it off
+        displayClear(target);
+
+        // set the entry mode
+        //writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, LCD_SETDDRAMADDR, LCD_ENTRYMODESET | LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT);
+        target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 1 * Grove_LCD_RGB_Constants.MS_TO_NS);
+
+        setCursor(target, 0, 0);
+        target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, 1 * Grove_LCD_RGB_Constants.MS_TO_NS);
+        target.i2cFlushBatch();
+        return true;
+    }
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will set its currently displayd text and color.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param text String to display on the Grove RGB LCD.
+     * @param r 0-255 value for the Red color.
+     * @param g 0-255 value for the Green color.
+     * @param b 0-255 value for the Blue color.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     * target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean commandForTextAndColor(CommandChannel target, String text, int r, int g, int b) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+
+        showRGBColor(target, r, g, b);
+        showTwoLineText(target, text);
+        target.i2cFlushBatch();
+        return true;
+    }
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will set its currently displayed color.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param r 0-255 value for the Red color.
+     * @param g 0-255 value for the Green color.
+     * @param b 0-255 value for the Blue color.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     * target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean commandForColor(CommandChannel target, int r, int g, int b) {
+
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+
+        showRGBColor(target, r, g, b);
+
+        target.i2cFlushBatch();
+        return true;
+    }
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will set its currently displayed color.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param text String to display on the Grove LCD RGB device.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     * target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean commandForText(CommandChannel target, CharSequence text) {
+
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+
+        showTwoLineText(target, text);
+        target.i2cFlushBatch();
+
+        return true;
+    }
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will turn it on or off. Defaults to on.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param on True if the display should be turned on, and false if it should be turned off.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     * target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean commandForDisplay(CommandChannel target, boolean on) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+
+        if (on) {
+            LCD_DISPLAY = Grove_LCD_RGB_Constants.LCD_DISPLAYON;
+        } else {
+            LCD_DISPLAY = Grove_LCD_RGB_Constants.LCD_DISPLAYOFF;
+        }
+
+        setDisplayControl(target);
+        target.i2cFlushBatch();
+        return true;
+    }
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will turn it on or off. Defaults to off.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param on True if the cursor should be turned on, and false if it should be turned off.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean commandForCursor(CommandChannel target, boolean on) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+
+        if (on) {
+            LCD_CURSOR = Grove_LCD_RGB_Constants.LCD_CURSORON;
+        } else {
+            LCD_CURSOR = Grove_LCD_RGB_Constants.LCD_CURSOROFF;
+        }
+
+        setDisplayControl(target);
+        target.i2cFlushBatch();
+
+        return true;
+    }
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will enable or disable
+     * cursor blinking. Defaults to off.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param on True if blinking should be turned on, and false if it should be turned off.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean commandForBlink(CommandChannel target, boolean on) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+
+        if (on) {
+            LCD_BLINK = Grove_LCD_RGB_Constants.LCD_BLINKON;
+        } else {
+            LCD_BLINK = Grove_LCD_RGB_Constants.LCD_BLINKOFF;
+        }
+
+        setDisplayControl(target);
+        target.i2cFlushBatch();
+
+        return true;
+    }
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will clear its display.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean clearDisplay(CommandChannel target) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+        displayClear(target);
+
+        target.i2cFlushBatch();
+        return true;
+    }
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will set its cursor position.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param col Column index to place the cursor at.
+     * @param row Row index to place the cursor at.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean setCursor(CommandChannel target, int col, int row) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+        col = (row == 0 ? col | 0x80 : col | 0xc0);
+        writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR,
+                                  col);
+        target.i2cFlushBatch();
+        return true;
+    }
+
+    /////////////////////////////
+    ////  Write text methods ////
+    /////////////////////////////
+
+    /**
+     * Sends a command to a given Grove LCD RGB device that will save a new custom character to its
+     * memory. Up to 8 custom characters can be saved on a single device.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param location location 0-7 to store the character map in the LCD.
+     * @param charMap Array of 8 bytes. Each byte is a row. Least significant 5 bits determines values within row.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean setCustomChar(CommandChannel target, int location, byte charMap[]) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+        if (!isStarted) {
+            begin(target);
+        }
+        assert (location < 8 && location >= 0) : "Only locations 0-7 are valid";
+        assert (charMap.length == 8) : "charMap must contain an array of 8 bytes";
+        location &= 0x7;
+        for (int i = 0; i < charMap.length; i++) {
+            charMap[i] &= 0x1F; //each element contains 5 bits
+        }
+
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)),
+                                  Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR,
+                                  Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR | (location << 3));
+        target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.CGRAM_SET_DELAY);
+        writeMultipleBytesToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS,
+                                     Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, charMap, 0, charMap.length);
+        target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.DDRAM_WRITE_DELAY);
+        target.i2cFlushBatch();
+
+        //begin(target); //TODO: Seems to be necessary, but shouldn't be
+        return true;
+    }
+
+    /**
+     * Writes an ASCII char with the specified ID to a cell on a given Grove RGB LCD device.
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param characterIdx Index/ID of the character to display. 0 - 7 are custom characters defined
+     *                     via {@link #setCustomChar(CommandChannel, int, byte[])}.
+     * @param col Column index to place the character on.
+     * @param row Row index to place the character on.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean writeChar(CommandChannel target, int characterIdx, int col, int row) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+        setCursor(target, col, row);
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)),
+                                  Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, characterIdx);
+        target.i2cDelay(Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.DDRAM_WRITE_DELAY);
+        target.i2cFlushBatch();
+
+        return true;
+    }
+
+    /**
+     * Writes multiple ASCII characters starting at a given cell and row on a given Grove RGB LCD device.
+     *
+     * TODO: What happens if the given column/row would cause the given array of characters to flow off-screen?
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param characterIdx Ordered byte array of indexes/IDs of the characters to display. 0 - 7 are custom characters
+     *                     defined via {@link #setCustomChar(CommandChannel, int, byte[])}.
+     * @param col Column index to begin writing the characters from.
+     * @param row Row index to begin writing the characters from.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean writeMultipleChars(CommandChannel target, byte[] characterIdx, int col, int row) { //TODO: creates lots of garbage
+        return writeMultipleChars(target, characterIdx, 0, characterIdx.length, col, row);
+    }
+
+    /**
+     * Writes multiple ASCII characters starting at a given cell and row on a given Grove RGB LCD device.
+     *
+     * TODO: What happens if the given column/row would cause the given array of characters to flow off-screen?
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param characterIdx Ordered byte array of indexes/IDs of the characters to display. 0 - 7 are custom characters
+     *                     defined via {@link #setCustomChar(CommandChannel, int, byte[])}.
+     * @param startIdx TODO:
+     * @param length TODO:
+     * @param col Column index to begin writing the characters from.
+     * @param row Row index to begin writing the characters from.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean writeMultipleChars(CommandChannel target, byte[] characterIdx, int startIdx, int length, int col, int row) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+        int iterator = startIdx;
+        int endOfLineIdx = 16 - col;
+        int steps = 4;
+        setCursor(target, col, row);
+
+        while (iterator < length) {
+            if (endOfLineIdx < Math.min(iterator + steps, length - 1)) {
+                writeMultipleBytesToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS,
+                                             Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR,
+                                             characterIdx, iterator, endOfLineIdx - iterator);
+                iterator = endOfLineIdx;
+                endOfLineIdx += 16;
+                row = (row + 1) & 1;
+                setCursor(target, col, row);
+            } else {
+                writeMultipleBytesToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS,
+                                             Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR,
+                                             characterIdx, iterator, Math.min(steps, length - iterator));
+                iterator += steps;
+            }
+        }
+        target.i2cFlushBatch();
+        return true;
+    }
+
+    /**
+     * Writes a sequence of characters starting at a given cell and row on a given Grove RGB LCD device.
+     *
+     * TODO: What happens if the given column/row would cause the given array of characters to flow off-screen?
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param text Text to write to the display.
+     * @param col Column index to begin writing the characters from.
+     * @param row Row index to begin writing the characters from.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean writeCharSequence(CommandChannel target, CharSequence text, int col, int row) {
+        return writeCharSequence(target, text, 0, text.length(), col, row);
+    }
+
+    /**
+     * Writes a sequence of characters starting at a given cell and row on a given Grove RGB LCD device.
+     *
+     * TODO: What happens if the given column/row would cause the given array of characters to flow off-screen?
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param text Text to write to the display.
+     * @param startIdx TODO:
+     * @param length TODO:
+     * @param col Column index to begin writing the characters from.
+     * @param row Row index to begin writing the characters from.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean writeCharSequence(CommandChannel target, CharSequence text, int startIdx, int length, int col, int row) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+        int iterator = startIdx;
+        int endOfLineIdx = 16 - col;
+        int steps = 4;
+        setCursor(target, col, row);
+
+        while (iterator < length) {
+            if (endOfLineIdx < Math.min(iterator + steps, length - 1)) {
+                writeCharSequenceToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS,
+                                            Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR,
+                                            text, iterator, endOfLineIdx - iterator);
+                iterator = endOfLineIdx;
+                endOfLineIdx += 16;
+                row = (row + 1) & 1;
+                setCursor(target, col, row);
+            } else {
+                writeCharSequenceToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS,
+                                            Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR,
+                                            text, iterator, Math.min(steps, length - iterator));
+                iterator += steps;
+            }
+        }
+
+        target.i2cFlushBatch();
+        return true;
+    }
+
+    /**
+     * TODO: What exactly does write padded int do that makes it necessary?
+     *
+     * @param target {@link CommandChannel} initialized via {@link #begin(CommandChannel)}.
+     * @param value Integer value to write.
+     * @param length TODO: Is is this the "padding" indicated by the method signature?
+     * @param col Column index to begin writing the characters from.
+     * @param row Row index to begin writing the characters from.
+     *
+     * @return True if the command was successfully sent, and false otherwise. False will be immediately returned if the
+     *         target is not {@link CommandChannel#i2cIsReady()}.
+     */
+    public static boolean writePaddedInt(CommandChannel target, int value, int length, int col, int row) {
+        if (!target.i2cIsReady()) {
+            return false;
+        }
+        writeCharSequence(target, String.format("%0" + length + "d", value), col, row);
+        return true;
+    }
+
+    //////////////////////////////
+    ///    Private Methods    ////
+    //////////////////////////////
+    private static void setDisplayControl(CommandChannel target) {
+        writeSingleByteToRegister(target, Grove_LCD_RGB_Constants.LCD_ADDRESS, Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR,
+                                  Grove_LCD_RGB_Constants.LCD_DISPLAYCONTROL | LCD_DISPLAY | LCD_CURSOR | LCD_BLINK);
+        target.i2cDelay((Grove_LCD_RGB_Constants.LCD_ADDRESS), Grove_LCD_RGB_Constants.DISPLAY_SWITCH_DELAY);
+    }
+
+    private static void showRGBColor(CommandChannel target, int r, int g, int b) {
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 0, 0);
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 1, 0);
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 0x08, 0xaa);
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 4, r);
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 3, g);
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.RGB_ADDRESS)), 2, b);
+    }
+
+    private static void displayClear(CommandChannel target) {
+        //clear display
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)),
+                                  Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, Grove_LCD_RGB_Constants.LCD_CLEARDISPLAY);
+        target.i2cDelay((Grove_LCD_RGB_Constants.LCD_ADDRESS), Grove_LCD_RGB_Constants.SCREEN_CLEAR_DELAY);
+    }
+
+    private static void showTwoLineText(CommandChannel target, CharSequence text) {
+        if (!isStarted) {
+            begin(target);
+        }
+        displayClear(target);
+
+        target.i2cDelay((Grove_LCD_RGB_Constants.LCD_ADDRESS), Grove_LCD_RGB_Constants.INPUT_SET_DELAY);
+
+        int p = 0;
+        int start = 0;
+        while (p < text.length()) {
+            if (text.charAt(p++) == '\n') {
+                writeSingleLine(target, text, start, p - 1);// -1 to skip the \n
+                start = p;
+            }
+        }
+        assert (p == text.length());
+        writeSingleLine(target, text, start, p);
+    }
+
+    private static void writeSingleLine(CommandChannel target, CharSequence line, int p, int limit) {
+        int steps = 4;
+
+        while (p < limit) {
+            writeUTF8ToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)),
+                                Grove_LCD_RGB_Constants.LCD_SETCGRAMADDR, line, p, Math.min(steps, limit - p));
+            p += steps;
+
+        }
+
+        //new line
+        writeSingleByteToRegister(target, ((Grove_LCD_RGB_Constants.LCD_ADDRESS)),
+                                  Grove_LCD_RGB_Constants.LCD_SETDDRAMADDR, 0xc0);
+    }
+
+    private static void writeSingleByteToRegister(CommandChannel target, int address, int register, int value) {
+        DataOutputBlobWriter<I2CCommandSchema> i2cPayloadWriter = target.i2cCommandOpen(address);
+
+        i2cPayloadWriter.writeByte(register);
+        i2cPayloadWriter.writeByte(value);
+
+        target.i2cCommandClose();
+    }
+
+    private static void writeMultipleBytesToRegister(CommandChannel target, int address, int register, byte[] values, int startIdx, int length) {
+        DataOutputBlobWriter<I2CCommandSchema> i2cPayloadWriter = target.i2cCommandOpen(address);
+
+        i2cPayloadWriter.writeByte(register);
+        for (int i = startIdx; i < startIdx + length; i++) {
+            i2cPayloadWriter.writeByte(values[i]);
+        }
+
+        target.i2cCommandClose();
+    }
+
+    private static void writeCharSequenceToRegister(CommandChannel target, int address, int register, CharSequence values, int startIdx, int length) {
+        DataOutputBlobWriter<I2CCommandSchema> i2cPayloadWriter = target.i2cCommandOpen(address);
+
+        i2cPayloadWriter.writeByte(register);
+        i2cPayloadWriter.writeASCII(values.subSequence(startIdx, startIdx + length));
+
+        target.i2cCommandClose();
+    }
+
+    private static void writeUTF8ToRegister(CommandChannel target, int address, int register, CharSequence text, int pos, int len) {
+        DataOutputBlobWriter<I2CCommandSchema> i2cPayloadWriter = target.i2cCommandOpen(address);
+
+        i2cPayloadWriter.writeByte(register);
+        DataOutputBlobWriter.encodeAsUTF8(i2cPayloadWriter, text, pos, len);
+
+        target.i2cCommandClose();
+    }
+
+    @Override
+    public boolean isInput() {
+        return false;
+    }
+
+    @Override
+    public boolean isOutput() {
+        return true;
+    }
+
+    @Override
+    public boolean isPWM() {
+        return false;
+    }
+
+    @Override
+    public int range() {
+        return 0;
+    }
+
+    @Override
+    public I2CConnection getI2CConnection() { //putting getI2CConnection in i2cOutput twigs allows setup commands to be sent
+        byte[] LCD_READCMD = {};
+        byte[] LCD_SETUP = {};
+        byte LCD_ADDR = 0x04;
+        byte LCD_BYTESTOREAD = 0;
+        byte LCD_REGISTER = 0;
+        return new I2CConnection(this, LCD_ADDR, LCD_READCMD, LCD_BYTESTOREAD, LCD_REGISTER, LCD_SETUP);
+    }
+
+    @Override
+    public int response() {
+        return 20;
+    }
+
+    @Override
+    public boolean isValid(byte[] backing, int position, int length, int mask) {
+        return true;
+    }
+
+    @Override
+    public int pinsUsed() {
+        return 1;
+    }
 }

--- a/src/main/java/com/ociweb/iot/grove/Grove_LCD_RGB_Constants.java
+++ b/src/main/java/com/ociweb/iot/grove/Grove_LCD_RGB_Constants.java
@@ -1,84 +1,85 @@
 package com.ociweb.iot.grove;
 
 /*
- * Constants derived from Seeed LCD with RGB backlight data sheet here:
- * http://www.seeedstudio.com/wiki/images/0/03/JHD1214Y_YG_1.0.pdf
+ * Static constants for use with a Grove LCD RGB display.
  *
+ * @author Nathan Tippy
+ *
+ * TODO: This resolves to a blank page?
+ * @see http://www.seeedstudio.com/wiki/images/0/03/JHD1214Y_YG_1.0.pdf
  */
 public class Grove_LCD_RGB_Constants {
 
 	// Device I2C Adress (note this only uses the lower 7 bits)
-		public static int LCD_ADDRESS  =   (0x7c>>1); //  11 1110  0x3E
-		public static final int RGB_ADDRESS  =   (0xc4>>1); // 110 0010  0x62
+	public static int LCD_ADDRESS  =   (0x7c>>1); //  11 1110  0x3E
+	public static final int RGB_ADDRESS  =   (0xc4>>1); // 110 0010  0x62
 
+	// Color define
+	public static final int WHITE       =    0;
+	public static final int RED         =    1;
+	public static final int GREEN       =    2;
+	public static final int BLUE        =    3;
 
-		// color define 
-		public static final int WHITE       =    0;
-		public static final int RED         =    1;
-		public static final int GREEN       =    2;
-		public static final int BLUE        =    3;
+	public static final int REG_RED     =    0x04;        // pwm2
+	public static final int REG_GREEN   =    0x03;        // pwm1
+	public static final int REG_BLUE    =    0x02;        // pwm0
 
-		public static final int REG_RED     =    0x04;        // pwm2
-		public static final int REG_GREEN   =    0x03;        // pwm1
-		public static final int REG_BLUE    =    0x02;        // pwm0
+	public static final int REG_MODE1    =   0x00;
+	public static final int REG_MODE2    =   0x01;
+	public static final int REG_OUTPUT   =   0x08;
 
-		public static final int REG_MODE1    =   0x00;
-		public static final int REG_MODE2    =   0x01;
-		public static final int REG_OUTPUT   =   0x08;
+	// Commands
+	public static final int LCD_CLEARDISPLAY   =0x01;
+	public static final int LCD_RETURNHOME     =0x02;
+	public static final int LCD_ENTRYMODESET   =0x04;
+	public static final int LCD_DISPLAYCONTROL =0x08;
+	public static final int LCD_CURSORSHIFT    =0x10;
+	public static final int LCD_FUNCTIONSET    =0x20;
+	public static final int LCD_TWO_LINES      =0x28;
+	public static final int LCD_SETCGRAMADDR   =0x40;
+	public static final int LCD_SETDDRAMADDR   =0x80;
 
-		// commands
-		public static final int LCD_CLEARDISPLAY   =0x01;
-		public static final int LCD_RETURNHOME     =0x02;
-		public static final int LCD_ENTRYMODESET   =0x04;
-		public static final int LCD_DISPLAYCONTROL =0x08;
-		public static final int LCD_CURSORSHIFT    =0x10;
-		public static final int LCD_FUNCTIONSET    =0x20;
-		public static final int LCD_TWO_LINES      =0x28;
-		public static final int LCD_SETCGRAMADDR   =0x40;
-		public static final int LCD_SETDDRAMADDR   =0x80;
+	// Flags for display entry mode
+	public static final int LCD_ENTRYRIGHT          =0x00;
+	public static final int LCD_ENTRYLEFT           =0x02;
+	public static final int LCD_ENTRYSHIFTINCREMENT =0x01;
+	public static final int LCD_ENTRYSHIFTDECREMENT =0x00;
 
-		// flags for display entry mode
-		public static final int LCD_ENTRYRIGHT          =0x00;
-		public static final int LCD_ENTRYLEFT           =0x02;
-		public static final int LCD_ENTRYSHIFTINCREMENT =0x01;
-		public static final int LCD_ENTRYSHIFTDECREMENT =0x00;
+	// Flags for display on/off control
+	public static final int LCD_DISPLAYON  =0x04;
+	public static final int LCD_DISPLAYOFF =0x00;
+	public static final int LCD_CURSORON   =0x02;
+	public static final int LCD_CURSOROFF  =0x00;
+	public static final int LCD_BLINKON    =0x01;
+	public static final int LCD_BLINKOFF   =0x00;
 
-		// flags for display on/off control
-		public static final int LCD_DISPLAYON  =0x04;
-		public static final int LCD_DISPLAYOFF =0x00;
-		public static final int LCD_CURSORON   =0x02;
-		public static final int LCD_CURSOROFF  =0x00;
-		public static final int LCD_BLINKON    =0x01;
-		public static final int LCD_BLINKOFF   =0x00;
+	// Flags for display/cursor shift
+	public static final int LCD_DISPLAYMOVE =0x08;
+	public static final int LCD_CURSORMOVE  =0x00;
+	public static final int LCD_MOVERIGHT   =0x04;
+	public static final int LCD_MOVELEFT    =0x00;
 
-		
+	// Flags for function set
+	public static final int LCD_8BITMODE =0x10;
+	public static final int LCD_4BITMODE =0x00;
+	public static final int LCD_2LINE =0x08;
+	public static final int LCD_1LINE =0x00;
+	public static final int LCD_5x10DOTS =0x04;
+	public static final int LCD_5x8DOTS =0x00;
 
-		// flags for display/cursor shift
-		public static final int LCD_DISPLAYMOVE =0x08;
-		public static final int LCD_CURSORMOVE  =0x00;
-		public static final int LCD_MOVERIGHT   =0x04;
-		public static final int LCD_MOVELEFT    =0x00;
+	public static final int SCREEN_CLEAR_DELAY = 1_530_000;
+	public static final int CURSOR_RETURN_DELAY = 1_530_000;
+	public static final int INPUT_SET_DELAY = 39_000;
+	public static final int DISPLAY_SWITCH_DELAY = 39_000;
+	public static final int SHIFT_DELAY = 39_000;
+	public static final int FUNCTION_SET_DELAY = 39_000;
+	public static final int CGRAM_SET_DELAY = 39_000;
+	public static final int DDRAM_SET_DELAY = 39_000;
+	public static final int DDRAM_WRITE_DELAY = 43_000;
 
-		// flags for function set
-		public static final int LCD_8BITMODE =0x10;
-		public static final int LCD_4BITMODE =0x00;
-		public static final int LCD_2LINE =0x08;
-		public static final int LCD_1LINE =0x00;
-		public static final int LCD_5x10DOTS =0x04;
-		public static final int LCD_5x8DOTS =0x00;
-		
-		public static boolean isStarted = false;
+    // TODO: Why is this protected?
+    protected static final long MS_TO_NS = 1_000_000;
 
-	    protected static final long MS_TO_NS = 1_000_000;
-	    
-	    public static final int SCREEN_CLEAR_DELAY = 1_530_000;
-	    public static final int CURSOR_RETURN_DELAY = 1_530_000;
-	    public static final int INPUT_SET_DELAY = 39_000;
-	    public static final int DISPLAY_SWITCH_DELAY = 39_000;
-	    public static final int SHIFT_DELAY = 39_000;
-	    public static final int FUNCTION_SET_DELAY = 39_000;
-	    public static final int CGRAM_SET_DELAY = 39_000;
-	    public static final int DDRAM_SET_DELAY = 39_000;
-	    public static final int DDRAM_WRITE_DELAY = 43_000;
-
+    // TODO: Static global state ok?
+    public static boolean isStarted = false;
 }

--- a/src/main/java/com/ociweb/iot/grove/Grove_LCD_RGB_Patterns.java
+++ b/src/main/java/com/ociweb/iot/grove/Grove_LCD_RGB_Patterns.java
@@ -1,11 +1,14 @@
 package com.ociweb.iot.grove;
 
+/**
+ * Various static byte arrays for common shapes that can be displayed
+ * on a Grove LCD RGB display
+ * 
+ * @author Nathan Tippy
+ */
 public class Grove_LCD_RGB_Patterns {
-	
-	
-	
-	//suits
 
+	// Suits //////////////////////////////////////////////////////////////////
 	public static final byte[] spade = {
 			0b00100,
 			0b01110,
@@ -50,10 +53,7 @@ public class Grove_LCD_RGB_Patterns {
 			0b00100,	
 	};
 	
-	
-	
-	//emojis
-	
+	// Emojis /////////////////////////////////////////////////////////////////
 	public static final byte[] smiley = {
 			0b00000,
 			0b01010,
@@ -131,11 +131,8 @@ public class Grove_LCD_RGB_Patterns {
 			0b00000,
 			0b00000,	
 	};
-	
-	
-	
-	// Arrows
-	
+
+	// Arrows /////////////////////////////////////////////////////////////////
 	public static final byte[] upArrow = {
 			0b00000,
 			0b00100,
@@ -181,8 +178,7 @@ public class Grove_LCD_RGB_Patterns {
 	};
 	
 	
-	//Patterns
-	
+	// Patterns ///////////////////////////////////////////////////////////////
 	public static final byte[] dithered = {
 			0b10101,
 			0b01010,


### PR DESCRIPTION
Cleans up formatting of Grove LCD RGB files and adds javadocs to public methods. There were a few I weren't sure about, so I inserted TODOs for them as appropriate.